### PR TITLE
Updating intro.tex: modify Page13, Eq (1.26)

### DIFF
--- a/intro/intro.tex
+++ b/intro/intro.tex
@@ -478,7 +478,7 @@ close, to the solution and we will solve for a correction, $\Delta
 \end{equation}
 Using this approximation, we can expand the righthand side vector,
 \begin{equation}
-{\bf f}(t^{n+1},{\bf y}^{n+1}) = {\bf f}(t^n, {\bf y}^{n+1}_0) +
+{\bf f}(t^{n+1},{\bf y}^{n+1}) = {\bf f}(t^{n+1}, {\bf y}^{n+1}_0) +
      \left . \frac{\partial {\bf f}}{\partial {\bf y}} \right |_0 \Delta {\bf y}_0 + \ldots 
 \end{equation} 
 Here we recognize the Jacobin matrix, ${\bf J} \equiv \partial {\bf


### PR DESCRIPTION
I believe that Eq. (1.26) does not want expansions on time. I changed the superscript of "t" on the right hand side from "n" to "n+1".
PS: I think the subscript of the Jacobin matrix here, "0", may be confusing since the matrix uses digits (1-n) as the subscriptions of its elements. Maybe a few more explanations will make it clearer. Thanks.
